### PR TITLE
Xp Tracking overlay

### DIFF
--- a/src/main/java/com/xpdrops/CustomizableXpDropsPlugin.java
+++ b/src/main/java/com/xpdrops/CustomizableXpDropsPlugin.java
@@ -133,6 +133,8 @@ public class CustomizableXpDropsPlugin extends Plugin
 	{
 		overlayManager.remove(xpTrackerOverlay);
 		overlayManager.remove(xpDropOverlay);
+		final Widget xpTracker = client.getWidget(122,0);
+		xpTracker.setHidden(false);
 	}
 
 	@Subscribe
@@ -205,9 +207,20 @@ public class CustomizableXpDropsPlugin extends Plugin
 			final int widgetId = intStack[intStackSize - 4];
 
 			final Widget xpdrop = client.getWidget(widgetId);
+			final Widget xpTracker = client.getWidget(122,0);
 			if (xpdrop != null)
 			{
 				xpdrop.setHidden(true);
+			}
+
+			//TODO: Default xp tracker isn't showing back up when custom xp tracker turned off
+			if(config.useXpTracker())
+			{
+				xpTracker.setHidden(true);
+			}
+			else
+			{
+				xpTracker.setHidden(false);
 			}
 		}
 	}

--- a/src/main/java/com/xpdrops/CustomizableXpDropsPlugin.java
+++ b/src/main/java/com/xpdrops/CustomizableXpDropsPlugin.java
@@ -51,6 +51,8 @@ public class CustomizableXpDropsPlugin extends Plugin
 	@Inject
 	private XpDropOverlay xpDropOverlay;
 
+	@Inject XpTrackerOverlay xpTrackerOverlay;
+
 	@Inject
 	private XpDropsConfig config;
 
@@ -104,6 +106,7 @@ public class CustomizableXpDropsPlugin extends Plugin
 		}
 		queue.clear();
 
+		overlayManager.add(xpTrackerOverlay);
 		overlayManager.add(xpDropOverlay);
 
 		filteredSkillsPredictedHits.clear();
@@ -128,6 +131,7 @@ public class CustomizableXpDropsPlugin extends Plugin
 	@Override
 	protected void shutDown()
 	{
+		overlayManager.remove(xpTrackerOverlay);
 		overlayManager.remove(xpDropOverlay);
 	}
 

--- a/src/main/java/com/xpdrops/CustomizableXpDropsPlugin.java
+++ b/src/main/java/com/xpdrops/CustomizableXpDropsPlugin.java
@@ -125,6 +125,13 @@ public class CustomizableXpDropsPlugin extends Plugin
 			filteredSkills.add("runecraft");
 		}
 
+		if(config.useXpTracker())
+		{
+			final Widget xpTracker = client.getWidget(122,0);
+			assert xpTracker != null;
+			xpTracker.setHidden(true);
+		}
+
 		xpDropDamageCalculator.populateMap();
 	}
 
@@ -134,6 +141,7 @@ public class CustomizableXpDropsPlugin extends Plugin
 		overlayManager.remove(xpTrackerOverlay);
 		overlayManager.remove(xpDropOverlay);
 		final Widget xpTracker = client.getWidget(122,0);
+		assert xpTracker != null;
 		xpTracker.setHidden(false);
 	}
 
@@ -162,6 +170,18 @@ public class CustomizableXpDropsPlugin extends Plugin
 				{
 					filteredSkillsPredictedHits.add("runecraft");
 				}
+			}
+
+			final Widget xpTracker = client.getWidget(122,0);
+			if(config.useXpTracker())
+			{
+				assert xpTracker != null;
+				xpTracker.setHidden(true);
+			}
+			else
+			{
+				assert xpTracker != null;
+				xpTracker.setHidden(false);
 			}
 		}
 	}
@@ -195,6 +215,7 @@ public class CustomizableXpDropsPlugin extends Plugin
 		}
 	}
 
+	//TODO: When the XPTrackerWidget gets hidden, this onScriptPreFired no longer gets called
 	@Subscribe
 	public void onScriptPreFired(ScriptPreFired scriptPreFired)
 	{
@@ -207,20 +228,9 @@ public class CustomizableXpDropsPlugin extends Plugin
 			final int widgetId = intStack[intStackSize - 4];
 
 			final Widget xpdrop = client.getWidget(widgetId);
-			final Widget xpTracker = client.getWidget(122,0);
 			if (xpdrop != null)
 			{
 				xpdrop.setHidden(true);
-			}
-
-			//TODO: Default xp tracker isn't showing back up when custom xp tracker turned off
-			if(config.useXpTracker())
-			{
-				xpTracker.setHidden(true);
-			}
-			else
-			{
-				xpTracker.setHidden(false);
 			}
 		}
 	}

--- a/src/main/java/com/xpdrops/XpDropsConfig.java
+++ b/src/main/java/com/xpdrops/XpDropsConfig.java
@@ -493,7 +493,7 @@ public interface XpDropsConfig extends Config
 
 	@ConfigItem(
 			keyName = "xpTrackerColor",
-			name = "XP Tracker Color",
+			name = "XP tracker color",
 			description = "Color for the Xp Tracker",
 			position = 27,
 			section = xp_tracker_settings

--- a/src/main/java/com/xpdrops/XpDropsConfig.java
+++ b/src/main/java/com/xpdrops/XpDropsConfig.java
@@ -475,8 +475,8 @@ public interface XpDropsConfig extends Config
 			position = 26,
 			section = xp_tracker_settings
 	)
-	default Skill xpTrackerSkill() {
-		return Skill.OVERALL;
+	default XpTrackerSkills xpTrackerSkill() {
+		return XpTrackerSkills.MOST_RECENT;
 	}
 
 	@ConfigItem(
@@ -493,8 +493,8 @@ public interface XpDropsConfig extends Config
 
 	@ConfigItem(
 			keyName = "xpTrackerColor",
-			name = "Overall XP Color",
-			description = "Color for the Overall Xp Tracker",
+			name = "XP Tracker Color",
+			description = "Color for the Xp Tracker",
 			position = 27,
 			section = xp_tracker_settings
 	)

--- a/src/main/java/com/xpdrops/XpDropsConfig.java
+++ b/src/main/java/com/xpdrops/XpDropsConfig.java
@@ -62,6 +62,13 @@ public interface XpDropsConfig extends Config
 	)
 	String predicted_hit = "predicted_hit";
 
+	@ConfigSection(
+			name = "xp tracker overlay",
+			description = "Settings relating to the xp tracker",
+			position = 4
+	)
+	String xp_tracker_settings = "xp_tracker_settings";
+
 	@ConfigItem(
 		keyName = "grouped",
 		name = "Group XP drops",
@@ -434,5 +441,41 @@ public interface XpDropsConfig extends Config
 	default double xpMultiplier()
 	{
 		return 1;
+	}
+
+	@ConfigItem(
+			keyName = "useCustomXpTracker",
+			name = "Use custom xp tracker",
+			description = "Turn custom xp tracker on or off",
+			position = 24,
+			section = xp_tracker_settings
+	)
+	default boolean useCustomXpTracker()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+			keyName = "xpTrackerFontSize",
+			name = "XP tracker font size",
+			description = "Size of font for the XP Tracker overlay",
+			position = 24,
+			section = xp_tracker_settings
+	)
+	default int xpTrackerFontSize()
+	{
+		return 16;
+	}
+
+	@ConfigItem(
+			keyName = "xpTrackerColor",
+			name = "Overall XP Color",
+			description = "Color for the Overall Xp Tracker",
+			position = 15,
+			section = xp_tracker_settings
+	)
+	default Color xpTrackerColor()
+	{
+		return Color.white;
 	}
 }

--- a/src/main/java/com/xpdrops/XpDropsConfig.java
+++ b/src/main/java/com/xpdrops/XpDropsConfig.java
@@ -1,5 +1,6 @@
 package com.xpdrops;
 
+import net.runelite.api.Skill;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -444,22 +445,45 @@ public interface XpDropsConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "useCustomXpTracker",
-			name = "Use custom xp tracker",
+			keyName = "useXpTracker",
+			name = "Use xp tracker",
 			description = "Turn custom xp tracker on or off",
 			position = 24,
 			section = xp_tracker_settings
 	)
-	default boolean useCustomXpTracker()
+	default boolean useXpTracker()
 	{
 		return false;
+	}
+
+	@ConfigItem(
+			keyName = "showIconsXpTracker",
+			name = "Show icons xp tracker",
+			description = "Turn on skill icons for xp tracker",
+			position = 25,
+			section = xp_tracker_settings
+	)
+	default boolean showIconsXpTracker()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "xpTrackerSkill",
+			name = "Xp tracker skill",
+			description = "Skill to display within the Xp Tracker",
+			position = 26,
+			section = xp_tracker_settings
+	)
+	default Skill xpTrackerSkill() {
+		return Skill.OVERALL;
 	}
 
 	@ConfigItem(
 			keyName = "xpTrackerFontSize",
 			name = "XP tracker font size",
 			description = "Size of font for the XP Tracker overlay",
-			position = 24,
+			position = 26,
 			section = xp_tracker_settings
 	)
 	default int xpTrackerFontSize()
@@ -471,7 +495,7 @@ public interface XpDropsConfig extends Config
 			keyName = "xpTrackerColor",
 			name = "Overall XP Color",
 			description = "Color for the Overall Xp Tracker",
-			position = 15,
+			position = 27,
 			section = xp_tracker_settings
 	)
 	default Color xpTrackerColor()

--- a/src/main/java/com/xpdrops/XpTrackerOverlay.java
+++ b/src/main/java/com/xpdrops/XpTrackerOverlay.java
@@ -116,7 +116,7 @@ public class XpTrackerOverlay extends Overlay {
         int width = graphics.getFontMetrics().stringWidth(pattern);
         int height = graphics.getFontMetrics().getHeight();
 
-        if (config.xpTrackerSkill().equals(Skill.OVERALL))
+        if (config.xpTrackerSkill().equals(XpTrackerSkills.OVERALL))
         {
             text = xpFormatter.format(overallXp);
         }
@@ -189,7 +189,7 @@ public class XpTrackerOverlay extends Overlay {
     private void update()
     {
         updateFont();
-        updateXpTracker(config.xpTrackerSkill());
+        updateXpTracker();
     }
 
     private void updateFont()
@@ -258,8 +258,9 @@ public class XpTrackerOverlay extends Overlay {
         }
     }
 
-    private void updateXpTracker(Skill skill)
+    private void updateXpTracker()
     {
+        Skill skill = determineSkill();
         if (skill.equals(Skill.OVERALL))
         {
             overallXp = client.getOverallExperience();
@@ -268,5 +269,69 @@ public class XpTrackerOverlay extends Overlay {
         {
             skillXp = client.getSkillExperience(skill);
         }
+    }
+
+    private Skill determineSkill()
+    {
+        if (config.xpTrackerSkill().equals(XpTrackerSkills.MOST_RECENT))
+        {
+            for (XpDrop xpDrop : plugin.getQueue())
+            {
+                return xpDrop.getSkill();
+            }
+        }
+
+        switch (config.xpTrackerSkill())
+        {
+            case OVERALL:
+                return Skill.OVERALL;
+            case ATTACK:
+                return Skill.ATTACK;
+            case STRENGTH:
+                return Skill.STRENGTH;
+            case DEFENCE:
+                return Skill.DEFENCE;
+            case HITPOINTS:
+                return Skill.HITPOINTS;
+            case RANGED:
+                return Skill.RANGED;
+            case PRAYER:
+                return Skill.PRAYER;
+            case MAGIC:
+                return Skill.MAGIC;
+            case RUNECRAFT:
+                return Skill.RUNECRAFT;
+            case CONSTRUCTION:
+                return Skill.CONSTRUCTION;
+            case AGILITY:
+                return Skill.AGILITY;
+            case HERBLORE:
+                return Skill.HERBLORE;
+            case THEIVING:
+                return Skill.THIEVING;
+            case CRAFTING:
+                return Skill.CRAFTING;
+            case FLETCHING:
+                return Skill.FLETCHING;
+            case SLAYER:
+                return Skill.SLAYER;
+            case HUNTER:
+                return Skill.HUNTER;
+            case MINING:
+                return Skill.MINING;
+            case SMITHING:
+                return Skill.SMITHING;
+            case FISHING:
+                return Skill.FISHING;
+            case COOKING:
+                return Skill.COOKING;
+            case FIREMAKING:
+                return Skill.FIREMAKING;
+            case WOODCUTTING:
+                return Skill.WOODCUTTING;
+            case FARMING:
+                return Skill.FARMING;
+        }
+        return Skill.OVERALL;
     }
 }

--- a/src/main/java/com/xpdrops/XpTrackerOverlay.java
+++ b/src/main/java/com/xpdrops/XpTrackerOverlay.java
@@ -43,7 +43,7 @@ public class XpTrackerOverlay extends Overlay {
     {
         this.plugin = plugin;
         this.config = config;
-        setLayer(OverlayLayer.ABOVE_WIDGETS);
+        setLayer(OverlayLayer.UNDER_WIDGETS);
         setPosition(OverlayPosition.TOP_RIGHT);
     }
 

--- a/src/main/java/com/xpdrops/XpTrackerOverlay.java
+++ b/src/main/java/com/xpdrops/XpTrackerOverlay.java
@@ -14,6 +14,7 @@ import java.text.DecimalFormat;
 
 public class XpTrackerOverlay extends Overlay {
 
+    protected static final int TOTAL_LEVEL_ICON = 898;
     protected static final float FRAMES_PER_SECOND = 50;
     protected static final String pattern = "#,###,###,###";
     protected static final DecimalFormat xpFormatter = new DecimalFormat(pattern);
@@ -115,6 +116,7 @@ public class XpTrackerOverlay extends Overlay {
     {
         graphics.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
         String text = "";
+        boolean isOverall = false;
         handleFont(graphics);
 
         int width = graphics.getFontMetrics().stringWidth(pattern);
@@ -123,6 +125,7 @@ public class XpTrackerOverlay extends Overlay {
         if (config.xpTrackerSkill().equals(XpTrackerSkills.OVERALL))
         {
             text = xpFormatter.format(overallXp);
+            isOverall = true;
         }
         else
         {
@@ -134,21 +137,31 @@ public class XpTrackerOverlay extends Overlay {
 
         int imageY = textY - graphics.getFontMetrics().getMaxAscent();
 
-        int imageWidth = drawIcons(graphics, 0, imageY, 0xff);
+        int imageWidth = drawIcons(graphics, 0, imageY, 0xff, isOverall);
 
         drawText(graphics, text, imageWidth, textY);
 
         return textX + imageWidth;
     }
 
-    private int drawIcons(Graphics2D graphics, int x, int y, float alpha)
+    private int drawIcons(Graphics2D graphics, int x, int y, float alpha, boolean isOverallXp)
     {
         int width = 0;
         int iconSize = graphics.getFontMetrics().getHeight();
+        BufferedImage image;
 
         if (config.showIconsXpTracker())
         {
-            BufferedImage image = STAT_ICONS[icon];
+            //if the skill we're tracking is not OverallXp, get the icon from the array of bufferedImages using the icon ID
+            if(!isOverallXp)
+            {
+                image = STAT_ICONS[icon];
+            }
+            //If we're tracking OverallXp, get the Skills Tab icon by getting the icon from the spriteList, using ID 898
+            else
+            {
+                image = plugin.getIcon(898, 0);
+            }
             int _iconSize = Math.max(iconSize, 18);
             int iconWidth = image.getWidth() * _iconSize / 25;
             int iconHeight = image.getHeight() * _iconSize / 25;
@@ -283,7 +296,6 @@ public class XpTrackerOverlay extends Overlay {
         switch (xpTrackerSkills)
         {
             case "OVERALL":
-                //icon = 23;
                 return Skill.OVERALL;
             case "ATTACK":
                 icon = 0;

--- a/src/main/java/com/xpdrops/XpTrackerOverlay.java
+++ b/src/main/java/com/xpdrops/XpTrackerOverlay.java
@@ -100,11 +100,9 @@ public class XpTrackerOverlay extends Overlay {
             setLayer(OverlayLayer.UNDER_WIDGETS);
             setPosition(OverlayPosition.TOP_RIGHT);
 
-            drawXpTracker(graphics);
-
             FontMetrics fontMetrics = graphics.getFontMetrics();
 
-            int width = fontMetrics.stringWidth(pattern);
+            int width = drawXpTracker(graphics);
             int height = fontMetrics.getHeight();
 
             lastFrameTime = System.currentTimeMillis();
@@ -113,7 +111,7 @@ public class XpTrackerOverlay extends Overlay {
         return new Dimension(0,0);
     }
 
-    protected void drawXpTracker(Graphics2D graphics)
+    protected int drawXpTracker(Graphics2D graphics)
     {
         graphics.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
         String text = "";
@@ -136,12 +134,14 @@ public class XpTrackerOverlay extends Overlay {
 
         int imageY = textY - graphics.getFontMetrics().getMaxAscent();
 
-        int imageWidth = drawIcons(graphics, 0, imageY, 0xff, true);
+        int imageWidth = drawIcons(graphics, 0, imageY, 0xff);
 
         drawText(graphics, text, imageWidth, textY);
+
+        return textX + imageWidth;
     }
 
-    private int drawIcons(Graphics2D graphics, int x, int y, float alpha, boolean rightToLeft)
+    private int drawIcons(Graphics2D graphics, int x, int y, float alpha)
     {
         int width = 0;
         int iconSize = graphics.getFontMetrics().getHeight();
@@ -152,27 +152,18 @@ public class XpTrackerOverlay extends Overlay {
             int _iconSize = Math.max(iconSize, 18);
             int iconWidth = image.getWidth() * _iconSize / 25;
             int iconHeight = image.getHeight() * _iconSize / 25;
-            Dimension dimension = drawIcon(graphics, image, x, y, iconWidth, iconHeight, alpha / 0xff, rightToLeft);
+            Dimension dimension = drawIcon(graphics, image, x, y, iconWidth, iconHeight, alpha / 0xff);
 
-            if (rightToLeft)
-            {
-                x -= dimension.getWidth() + 2;
-            }
-            else
-            {
-                x += dimension.getWidth() + 2;
-            }
-            width += dimension.getWidth() + 2;
-            //return after we've gotten the first icon, since we only want to display 1 skill if multiple get xp at once
+            width += dimension.getWidth() + 1;
             return width;
         }
         return width;
     }
 
-    private Dimension drawIcon(Graphics2D graphics, BufferedImage image, int x, int y, int width, int height, float alpha, boolean rightToLeft)
+    private Dimension drawIcon(Graphics2D graphics, BufferedImage image, int x, int y, int width, int height, float alpha)
     {
         int yOffset = graphics.getFontMetrics().getHeight() / 2 - height / 2;
-        int xOffset = rightToLeft ? width : 0;
+        int xOffset = width;
 
         Composite composite = graphics.getComposite();
         graphics.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, alpha));
@@ -296,7 +287,7 @@ public class XpTrackerOverlay extends Overlay {
         switch (xpTrackerSkills)
         {
             case "OVERALL":
-                icon = 23;
+                //icon = 23;
                 return Skill.OVERALL;
             case "ATTACK":
                 icon = 0;

--- a/src/main/java/com/xpdrops/XpTrackerOverlay.java
+++ b/src/main/java/com/xpdrops/XpTrackerOverlay.java
@@ -15,11 +15,9 @@ import java.text.DecimalFormat;
 public class XpTrackerOverlay extends Overlay {
 
     protected static final int TOTAL_LEVEL_ICON = 898;
-    protected static final float FRAMES_PER_SECOND = 50;
     protected static final String pattern = "#,###,###,###";
     protected static final DecimalFormat xpFormatter = new DecimalFormat(pattern);
     protected static final BufferedImage[] STAT_ICONS = new BufferedImage[Skill.values().length - 1];
-    protected static final int[] SKILL_INDICES = new int[] {10, 0, 2, 4, 6, 1, 3, 5, 16, 15, 17, 12, 20, 14, 13, 7, 11, 8, 9, 18, 19, 22, 21};
 
     protected CustomizableXpDropsPlugin plugin;
     protected XpDropsConfig config;

--- a/src/main/java/com/xpdrops/XpTrackerOverlay.java
+++ b/src/main/java/com/xpdrops/XpTrackerOverlay.java
@@ -69,9 +69,11 @@ public class XpTrackerOverlay extends Overlay {
     {
         if (firstRender)
         {
-            //Default the xpTracker to Attack for first render
-            icon = 0;
-            currentSkill = Skill.ATTACK;
+            //If the user is using the MOST_RECENT, default to showing overall xp for the first render
+            if(config.xpTrackerSkill().equals(XpTrackerSkills.MOST_RECENT))
+            {
+                currentSkill = Skill.OVERALL;
+            }
 
             firstRender = false;
             initIcons();
@@ -105,6 +107,7 @@ public class XpTrackerOverlay extends Overlay {
 
             int width = drawXpTracker(graphics);
             int height = fontMetrics.getHeight();
+            height += Math.abs(config.xpTrackerFontSize() - fontMetrics.getHeight());
 
             lastFrameTime = System.currentTimeMillis();
             return new Dimension(width, height);
@@ -122,7 +125,7 @@ public class XpTrackerOverlay extends Overlay {
         int width = graphics.getFontMetrics().stringWidth(pattern);
         int height = graphics.getFontMetrics().getHeight();
 
-        if (config.xpTrackerSkill().equals(XpTrackerSkills.OVERALL))
+        if (currentSkill.equals(Skill.OVERALL))
         {
             text = xpFormatter.format(overallXp);
             isOverall = true;
@@ -133,11 +136,12 @@ public class XpTrackerOverlay extends Overlay {
         }
 
         int textY = height + graphics.getFontMetrics().getMaxAscent() - graphics.getFontMetrics().getHeight();
-        int textX = width - graphics.getFontMetrics().stringWidth(text);
+        int textX = width - (width - graphics.getFontMetrics().stringWidth(text));
 
         int imageY = textY - graphics.getFontMetrics().getMaxAscent();
 
-        int imageWidth = drawIcons(graphics, 0, imageY, 0xff, isOverall);
+        //Adding 5 onto image width to give a little space in between icon and text
+        int imageWidth = drawIcons(graphics, 0, imageY, 0xff, isOverall) + 5;
 
         drawText(graphics, text, imageWidth, textY);
 
@@ -167,7 +171,7 @@ public class XpTrackerOverlay extends Overlay {
             int iconHeight = image.getHeight() * _iconSize / 25;
             Dimension dimension = drawIcon(graphics, image, x, y, iconWidth, iconHeight, alpha / 0xff);
 
-            width += dimension.getWidth() + 1;
+            width += dimension.getWidth();
             return width;
         }
         return width;
@@ -180,7 +184,7 @@ public class XpTrackerOverlay extends Overlay {
 
         Composite composite = graphics.getComposite();
         graphics.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, alpha));
-        graphics.drawImage(image, x - xOffset, y + yOffset, width, height, null);
+        graphics.drawImage(image, x, y + yOffset, width, height, null);
         graphics.setComposite(composite);
         return new Dimension(width, height);
     }

--- a/src/main/java/com/xpdrops/XpTrackerOverlay.java
+++ b/src/main/java/com/xpdrops/XpTrackerOverlay.java
@@ -161,10 +161,10 @@ public class XpTrackerOverlay extends Overlay {
             {
                 image = STAT_ICONS[icon];
             }
-            //If we're tracking OverallXp, get the Skills Tab icon by getting the icon from the spriteList, using ID 898
+            //If we're tracking OverallXp, get the Skills Tab icon by getting the icon from the spriteList
             else
             {
-                image = plugin.getIcon(898, 0);
+                image = plugin.getIcon(TOTAL_LEVEL_ICON, 0);
             }
             int _iconSize = Math.max(iconSize, 18);
             int iconWidth = image.getWidth() * _iconSize / 25;

--- a/src/main/java/com/xpdrops/XpTrackerOverlay.java
+++ b/src/main/java/com/xpdrops/XpTrackerOverlay.java
@@ -9,6 +9,7 @@ import net.runelite.client.ui.overlay.OverlayPosition;
 
 import javax.inject.Inject;
 import java.awt.*;
+import java.awt.image.BufferedImage;
 import java.text.DecimalFormat;
 
 public class XpTrackerOverlay extends Overlay {
@@ -16,7 +17,8 @@ public class XpTrackerOverlay extends Overlay {
     protected static final float FRAMES_PER_SECOND = 50;
     protected static final String pattern = "#,###,###,###";
     protected static final DecimalFormat xpFormatter = new DecimalFormat(pattern);
-    protected static final float CONSTANT_FRAME_TIME = 1000.0f / FRAMES_PER_SECOND;
+    protected static final BufferedImage[] STAT_ICONS = new BufferedImage[Skill.values().length - 1];
+    protected static final int[] SKILL_INDICES = new int[] {10, 0, 2, 4, 6, 1, 3, 5, 16, 15, 17, 12, 20, 14, 13, 7, 11, 8, 9, 18, 19, 22, 21};
 
     protected CustomizableXpDropsPlugin plugin;
     protected XpDropsConfig config;
@@ -33,6 +35,7 @@ public class XpTrackerOverlay extends Overlay {
     private Client client;
 
     private Long overallXp;
+    private int skillXp;
 
     @Inject
     protected XpTrackerOverlay(CustomizableXpDropsPlugin plugin, XpDropsConfig config)
@@ -61,42 +64,66 @@ public class XpTrackerOverlay extends Overlay {
 
     protected void lazyInit()
     {
+        if (firstRender)
+        {
+            firstRender = false;
+            initIcons();
+        }
         if (lastFrameTime <= 0)
         {
             lastFrameTime = System.currentTimeMillis() - 20;
         }
     }
 
+    protected void initIcons()
+    {
+        for (int i = 0; i < STAT_ICONS.length; i++)
+        {
+            STAT_ICONS[i] = plugin.getSkillIcon(Skill.values()[i]);
+        }
+    }
+
     @Override
     public Dimension render(Graphics2D graphics)
     {
-        lazyInit();
-        update();
+        if (config.useXpTracker())
+        {
+            lazyInit();
+            update();
 
-        setLayer(OverlayLayer.ABOVE_WIDGETS);
-        setPosition(OverlayPosition.TOP_RIGHT);
+            setLayer(OverlayLayer.ABOVE_WIDGETS);
+            setPosition(OverlayPosition.TOP_RIGHT);
 
-        drawOverallXp(graphics);
+            drawXpTracker(graphics);
 
-        FontMetrics fontMetrics = graphics.getFontMetrics();
+            FontMetrics fontMetrics = graphics.getFontMetrics();
 
-        int width = fontMetrics.stringWidth(pattern);
-        int height = fontMetrics.getHeight();
+            int width = fontMetrics.stringWidth(pattern);
+            int height = fontMetrics.getHeight();
 
-        lastFrameTime = System.currentTimeMillis();
-        return new Dimension(width, height);
+            lastFrameTime = System.currentTimeMillis();
+            return new Dimension(width, height);
+        }
+        return new Dimension(0,0);
     }
 
-    protected void drawOverallXp(Graphics2D graphics)
+    protected void drawXpTracker(Graphics2D graphics)
     {
         graphics.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
-
+        String text = "";
         handleFont(graphics);
 
         int width = graphics.getFontMetrics().stringWidth(pattern);
         int height = graphics.getFontMetrics().getHeight();
 
-        String text = xpFormatter.format(overallXp);
+        if (config.xpTrackerSkill().equals(Skill.OVERALL))
+        {
+            text = xpFormatter.format(overallXp);
+        }
+        else
+        {
+            text = xpFormatter.format(skillXp);
+        }
 
         int textY = height + graphics.getFontMetrics().getMaxAscent() - graphics.getFontMetrics().getHeight();
         int textX = width - graphics.getFontMetrics().stringWidth(text);
@@ -114,10 +141,55 @@ public class XpTrackerOverlay extends Overlay {
         graphics.drawString(text, textX, textY);
     }
 
+    protected int drawIcons(Graphics2D graphics, int icons, int x, int y, float alpha, boolean rightToLeft)
+    {
+        int width = 0;
+        int iconSize = graphics.getFontMetrics().getHeight();
+        if (config.showIconsXpTracker())
+        {
+            for (int i = SKILL_INDICES.length - 1; i >= 0; i--)
+            {
+                int icon = (icons >> i) & 0x1;
+                if (icon == 0x1)
+                {
+                    int index = SKILL_INDICES[i];
+                    BufferedImage image = STAT_ICONS[index];
+                    int _iconSize = Math.max(iconSize, 18);
+                    int iconWidth = image.getWidth() * _iconSize / 25;
+                    int iconHeight = image.getHeight() * _iconSize / 25;
+                    Dimension dimension = drawIcon(graphics, image, x, y, iconWidth, iconHeight, alpha / 0xff, rightToLeft);
+
+                    if (rightToLeft)
+                    {
+                        x -= dimension.getWidth() + 2;
+                    }
+                    else
+                    {
+                        x += dimension.getWidth() + 2;
+                    }
+                    width += dimension.getWidth() + 2;
+                }
+            }
+        }
+        return width;
+    }
+
+    private Dimension drawIcon(Graphics2D graphics, BufferedImage image, int x, int y, int width, int height, float alpha, boolean rightToLeft)
+    {
+        int yOffset = graphics.getFontMetrics().getHeight() / 2 - height / 2;
+        int xOffset = rightToLeft ? width : 0;
+
+        Composite composite = graphics.getComposite();
+        graphics.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, alpha));
+        graphics.drawImage(image, x - xOffset, y + yOffset, width, height, null);
+        graphics.setComposite(composite);
+        return new Dimension(width, height);
+    }
+
     private void update()
     {
         updateFont();
-        updateOverallCounter();
+        updateXpTracker(config.xpTrackerSkill());
     }
 
     private void updateFont()
@@ -186,8 +258,15 @@ public class XpTrackerOverlay extends Overlay {
         }
     }
 
-    private void updateOverallCounter()
+    private void updateXpTracker(Skill skill)
     {
-        overallXp = client.getOverallExperience();
+        if (skill.equals(Skill.OVERALL))
+        {
+            overallXp = client.getOverallExperience();
+        }
+        else
+        {
+            skillXp = client.getSkillExperience(skill);
+        }
     }
 }

--- a/src/main/java/com/xpdrops/XpTrackerOverlay.java
+++ b/src/main/java/com/xpdrops/XpTrackerOverlay.java
@@ -1,0 +1,193 @@
+package com.xpdrops;
+
+import net.runelite.api.Client;
+import net.runelite.api.Skill;
+import net.runelite.client.ui.FontManager;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPosition;
+
+import javax.inject.Inject;
+import java.awt.*;
+import java.text.DecimalFormat;
+
+public class XpTrackerOverlay extends Overlay {
+
+    protected static final float FRAMES_PER_SECOND = 50;
+    protected static final String pattern = "#,###,###,###";
+    protected static final DecimalFormat xpFormatter = new DecimalFormat(pattern);
+    protected static final float CONSTANT_FRAME_TIME = 1000.0f / FRAMES_PER_SECOND;
+
+    protected CustomizableXpDropsPlugin plugin;
+    protected XpDropsConfig config;
+
+    protected String lastFont = "";
+    protected int lastFontSize = 0;
+    protected boolean useRunescapeFont = true;
+    protected XpDropsConfig.FontStyle lastFontStyle = XpDropsConfig.FontStyle.DEFAULT;
+    protected Font font = null;
+    protected boolean firstRender = true;
+    protected long lastFrameTime = 0;
+
+    @Inject
+    private Client client;
+
+    private Long overallXp;
+
+    @Inject
+    protected XpTrackerOverlay(CustomizableXpDropsPlugin plugin, XpDropsConfig config)
+    {
+        this.plugin = plugin;
+        this.config = config;
+        setLayer(OverlayLayer.ABOVE_WIDGETS);
+        setPosition(OverlayPosition.TOP_RIGHT);
+    }
+
+    /**
+     * Font provided by config menu item
+     * @param graphics
+     */
+    protected void handleFont(Graphics2D graphics)
+    {
+        if( font != null)
+        {
+            graphics.setFont(font);
+            if( useRunescapeFont)
+            {
+                graphics.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_OFF);
+            }
+        }
+    }
+
+    protected void lazyInit()
+    {
+        if (lastFrameTime <= 0)
+        {
+            lastFrameTime = System.currentTimeMillis() - 20;
+        }
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics)
+    {
+        lazyInit();
+        update();
+
+        setLayer(OverlayLayer.ABOVE_WIDGETS);
+        setPosition(OverlayPosition.TOP_RIGHT);
+
+        drawOverallXp(graphics);
+
+        FontMetrics fontMetrics = graphics.getFontMetrics();
+
+        int width = fontMetrics.stringWidth(pattern);
+        int height = fontMetrics.getHeight();
+
+        lastFrameTime = System.currentTimeMillis();
+        return new Dimension(width, height);
+    }
+
+    protected void drawOverallXp(Graphics2D graphics)
+    {
+        graphics.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+
+        handleFont(graphics);
+
+        int width = graphics.getFontMetrics().stringWidth(pattern);
+        int height = graphics.getFontMetrics().getHeight();
+
+        String text = xpFormatter.format(overallXp);
+
+        int textY = height + graphics.getFontMetrics().getMaxAscent() - graphics.getFontMetrics().getHeight();
+        int textX = width - graphics.getFontMetrics().stringWidth(text);
+
+        drawText(graphics, text, textX, textY);
+    }
+
+    protected void drawText(Graphics2D graphics, String text, int textX, int textY)
+    {
+        Color _color = config.xpTrackerColor();
+        Color backgroundColor = new Color(0,0,0);
+        graphics.setColor(backgroundColor);
+        graphics.drawString(text, textX + 1, textY + 1);
+        graphics.setColor(_color);
+        graphics.drawString(text, textX, textY);
+    }
+
+    private void update()
+    {
+        updateFont();
+        updateOverallCounter();
+    }
+
+    private void updateFont()
+    {
+        //only perform anything within this function if any settings related to the font have changed
+        if(!lastFont.equals(config.fontName()) || lastFontSize != config.xpTrackerFontSize() || lastFontStyle != config.fontStyle())
+        {
+            lastFont = config.fontName();
+            lastFontSize = config.xpTrackerFontSize();
+            lastFontStyle = config.fontStyle();
+
+            //use runescape font as default
+            if (config.fontName().equals(""))
+            {
+                if (config.xpTrackerFontSize() < 16)
+                {
+                    font = FontManager.getRunescapeSmallFont();
+                }
+                else if (config.fontStyle() == XpDropsConfig.FontStyle.BOLD || config.fontStyle() == XpDropsConfig.FontStyle.BOLD_ITALICS)
+                {
+                    font = FontManager.getRunescapeBoldFont();
+                }
+                else
+                {
+                    font = FontManager.getRunescapeFont();
+                }
+
+                if (config.xpTrackerFontSize() > 16)
+                {
+                    font = font.deriveFont((float)config.xpTrackerFontSize());
+                }
+
+                if (config.fontStyle() == XpDropsConfig.FontStyle.BOLD)
+                {
+                    font = font.deriveFont(Font.BOLD);
+                }
+                if (config.fontStyle() == XpDropsConfig.FontStyle.ITALICS)
+                {
+                    font = font.deriveFont(Font.ITALIC);
+                }
+                if (config.fontStyle() == XpDropsConfig.FontStyle.BOLD_ITALICS)
+                {
+                    font = font.deriveFont(Font.ITALIC | Font.BOLD);
+                }
+
+                useRunescapeFont = true;
+                return;
+            }
+
+            int style = Font.PLAIN;
+            switch (config.fontStyle())
+            {
+                case BOLD:
+                    style = Font.BOLD;
+                    break;
+                case ITALICS:
+                    style = Font.ITALIC;
+                    break;
+                case BOLD_ITALICS:
+                    style = Font.BOLD | Font.ITALIC;
+                    break;
+            }
+
+            font = new Font(config.fontName(), style, config.xpTrackerFontSize());
+            useRunescapeFont = false;
+        }
+    }
+
+    private void updateOverallCounter()
+    {
+        overallXp = client.getOverallExperience();
+    }
+}

--- a/src/main/java/com/xpdrops/XpTrackerOverlay.java
+++ b/src/main/java/com/xpdrops/XpTrackerOverlay.java
@@ -141,51 +141,6 @@ public class XpTrackerOverlay extends Overlay {
         graphics.drawString(text, textX, textY);
     }
 
-    protected int drawIcons(Graphics2D graphics, int icons, int x, int y, float alpha, boolean rightToLeft)
-    {
-        int width = 0;
-        int iconSize = graphics.getFontMetrics().getHeight();
-        if (config.showIconsXpTracker())
-        {
-            for (int i = SKILL_INDICES.length - 1; i >= 0; i--)
-            {
-                int icon = (icons >> i) & 0x1;
-                if (icon == 0x1)
-                {
-                    int index = SKILL_INDICES[i];
-                    BufferedImage image = STAT_ICONS[index];
-                    int _iconSize = Math.max(iconSize, 18);
-                    int iconWidth = image.getWidth() * _iconSize / 25;
-                    int iconHeight = image.getHeight() * _iconSize / 25;
-                    Dimension dimension = drawIcon(graphics, image, x, y, iconWidth, iconHeight, alpha / 0xff, rightToLeft);
-
-                    if (rightToLeft)
-                    {
-                        x -= dimension.getWidth() + 2;
-                    }
-                    else
-                    {
-                        x += dimension.getWidth() + 2;
-                    }
-                    width += dimension.getWidth() + 2;
-                }
-            }
-        }
-        return width;
-    }
-
-    private Dimension drawIcon(Graphics2D graphics, BufferedImage image, int x, int y, int width, int height, float alpha, boolean rightToLeft)
-    {
-        int yOffset = graphics.getFontMetrics().getHeight() / 2 - height / 2;
-        int xOffset = rightToLeft ? width : 0;
-
-        Composite composite = graphics.getComposite();
-        graphics.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, alpha));
-        graphics.drawImage(image, x - xOffset, y + yOffset, width, height, null);
-        graphics.setComposite(composite);
-        return new Dimension(width, height);
-    }
-
     private void update()
     {
         updateFont();

--- a/src/main/java/com/xpdrops/XpTrackerOverlay.java
+++ b/src/main/java/com/xpdrops/XpTrackerOverlay.java
@@ -256,7 +256,19 @@ public class XpTrackerOverlay extends Overlay {
 
     private void updateXpTracker()
     {
-        determineSkill();
+        if (config.xpTrackerSkill().equals(XpTrackerSkills.MOST_RECENT))
+        {
+            for (XpDrop xpDrop : plugin.getQueue())
+            {
+                currentSkill = selectSkill(xpDrop.getSkill().getName().toUpperCase());
+                break;
+            }
+        }
+        else
+        {
+            currentSkill = selectSkill(config.xpTrackerSkill().toString());
+        }
+
         if (currentSkill.equals(Skill.OVERALL))
         {
             overallXp = client.getOverallExperience();
@@ -264,22 +276,6 @@ public class XpTrackerOverlay extends Overlay {
         else
         {
             skillXp = client.getSkillExperience(currentSkill);
-        }
-    }
-
-    private void determineSkill()
-    {
-        if (config.xpTrackerSkill().equals(XpTrackerSkills.MOST_RECENT))
-        {
-            for (XpDrop xpDrop : plugin.getQueue())
-            {
-                 currentSkill = selectSkill(xpDrop.getSkill().getName().toUpperCase());
-                 break;
-            }
-        }
-        else
-        {
-            currentSkill = selectSkill(config.xpTrackerSkill().toString());
         }
     }
 

--- a/src/main/java/com/xpdrops/XpTrackerSkills.java
+++ b/src/main/java/com/xpdrops/XpTrackerSkills.java
@@ -1,0 +1,30 @@
+package com.xpdrops;
+
+public enum XpTrackerSkills
+{
+    OVERALL,
+    MOST_RECENT,
+    ATTACK,
+    STRENGTH,
+    DEFENCE,
+    HITPOINTS,
+    RANGED,
+    PRAYER,
+    MAGIC,
+    RUNECRAFT,
+    CONSTRUCTION,
+    AGILITY,
+    HERBLORE,
+    THEIVING,
+    CRAFTING,
+    FLETCHING,
+    SLAYER,
+    HUNTER,
+    MINING,
+    SMITHING,
+    FISHING,
+    COOKING,
+    FIREMAKING,
+    WOODCUTTING,
+    FARMING
+}


### PR DESCRIPTION
Hey there,

Really love your work with the CustomizableXpDrops plugin, I use it all the time, and really appreciate that you built it!

I made a few changes to add a custom Xp Tracker overlay. By default this overlay would be turned off, and the user can turn it on in the config settings under a new config section called xp_tracker_settings. It's a more minimalist approach to the xp tracker, removing the default xp tracker overlay, and showing only the numbers and icon of the skill you're currently tracking. Icons can also be turned off. There is a picklist of the skills that you can display on the xp Tracker, including your overall xp, or showing the xp of the most recent skill the player gained xp in. Other small adjustments can be made including the font size, and color of the xp tracker numbers.

Really hoping to see this added into your plugin. It's something that I would love to use personally, and I don't believe that it detracts from any of the other work that you've done on this plugin, and instead is just a simple addition.

Thanks again!