### PR TITLE
Change layer to under widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A plugin which allows you to customize XP drops in more ways than the default OS
 - Replace the XP tracker widget with a minimalistic one.
 
 #### Change log
+- v1.7.2.1 - Change xp drop overlay layer to UNDER_WIDGETS - `@Jbleezy`
 - v1.7.2 - Add alpha channel to color pickers.
 - v1.7.1 - Fix bug where xp drop icons were not properly loaded. Xp tracker most recent will now respect the filtered skills.
 - v1.7.0.1 - Update xp bonuses file for wilderness boss update.

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ dependencies {
 }
 
 group = 'com.xpdrops'
-version = '1.7.2'
+version = '1.7.2.1'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/com/xpdrops/overlay/XpDropOverlay.java
+++ b/src/main/java/com/xpdrops/overlay/XpDropOverlay.java
@@ -24,7 +24,7 @@ public class XpDropOverlay extends Overlay
 	{
 		this.config = config;
 		this.xpDropOverlayManager = xpDropOverlayManager;
-		setLayer(OverlayLayer.ABOVE_WIDGETS);
+		setLayer(OverlayLayer.UNDER_WIDGETS);
 		setPosition(OverlayPosition.TOP_RIGHT);
 	}
 


### PR DESCRIPTION
The default XP drops show under widgets.

This makes them the same.