### PR TITLE
fixed changing targets on the same tick as you attack

### DIFF
--- a/src/main/java/com/xpdrops/CustomizableXpDropsPlugin.java
+++ b/src/main/java/com/xpdrops/CustomizableXpDropsPlugin.java
@@ -363,59 +363,63 @@ public class CustomizableXpDropsPlugin extends Plugin
 	@Subscribe
 	protected void onFakeXpDrop(FakeXpDrop event)
 	{
-		int currentXp = event.getXp();
-		if (event.getXp() >= 20000000)
-		{
-			// fake-fake xp drop?
-			return;
-		}
-
-		if (event.getSkill() == Skill.HITPOINTS)
-		{
-			int hit;
-			if (lastOpponentIsPlayer)
+		clientThread.invokeLater(() -> {
+			int currentXp = event.getXp();
+			if (event.getXp() >= 20000000)
 			{
-				hit = xpDropDamageCalculator.calculateHitOnPlayer(lastOpponentId, currentXp, config.xpMultiplier());
+				// fake-fake xp drop?
+				return;
 			}
-			else
-			{
-				hit = xpDropDamageCalculator.calculateHitOnNpc(lastOpponentId, currentXp, config.xpMultiplier());
-			}
-			log.debug("Hit npc with fake hp xp drop xp:{} hit:{} npc_id:{}", currentXp, hit, lastOpponentId);
-			hitBuffer.add(new Hit(hit, lastOpponent, attackStyle));
-		}
 
-		XpDrop xpDrop = new XpDrop(event.getSkill(), currentXp, matchPrayerStyle(event.getSkill()), true, lastOpponent);
-		queue.add(xpDrop);
-	}
-
-	@Subscribe
-	protected void onStatChanged(StatChanged event)
-	{
-		int currentXp = event.getXp();
-		int previousXp = previous_exp[event.getSkill().ordinal()];
-		if (previousXp > 0 && currentXp - previousXp > 0)
-		{
 			if (event.getSkill() == Skill.HITPOINTS)
 			{
 				int hit;
 				if (lastOpponentIsPlayer)
 				{
-					hit = xpDropDamageCalculator.calculateHitOnPlayer(lastOpponentId, currentXp - previousXp, config.xpMultiplier());
+					hit = xpDropDamageCalculator.calculateHitOnPlayer(lastOpponentId, currentXp, config.xpMultiplier());
 				}
 				else
 				{
-					hit = xpDropDamageCalculator.calculateHitOnNpc(lastOpponentId, currentXp - previousXp, config.xpMultiplier());
+					hit = xpDropDamageCalculator.calculateHitOnNpc(lastOpponentId, currentXp, config.xpMultiplier());
 				}
-				log.debug("Hit npc with hp xp drop xp:{} hit:{} npc_id:{}", currentXp - previousXp, hit, lastOpponentId);
+				log.debug("Hit npc with fake hp xp drop xp:{} hit:{} npc_id:{}", currentXp, hit, lastOpponentId);
 				hitBuffer.add(new Hit(hit, lastOpponent, attackStyle));
 			}
 
-			XpDrop xpDrop = new XpDrop(event.getSkill(), currentXp - previousXp, matchPrayerStyle(event.getSkill()), false, lastOpponent);
+			XpDrop xpDrop = new XpDrop(event.getSkill(), currentXp, matchPrayerStyle(event.getSkill()), true, lastOpponent);
 			queue.add(xpDrop);
-		}
+		});
+	}
 
-		previous_exp[event.getSkill().ordinal()] = event.getXp();
+	@Subscribe
+	protected void onStatChanged(StatChanged event)
+	{
+		clientThread.invokeLater(() -> {
+			int currentXp = event.getXp();
+			int previousXp = previous_exp[event.getSkill().ordinal()];
+			if (previousXp > 0 && currentXp - previousXp > 0)
+			{
+				if (event.getSkill() == Skill.HITPOINTS)
+				{
+					int hit;
+					if (lastOpponentIsPlayer)
+					{
+						hit = xpDropDamageCalculator.calculateHitOnPlayer(lastOpponentId, currentXp - previousXp, config.xpMultiplier());
+					}
+					else
+					{
+						hit = xpDropDamageCalculator.calculateHitOnNpc(lastOpponentId, currentXp - previousXp, config.xpMultiplier());
+					}
+					log.debug("Hit npc with hp xp drop xp:{} hit:{} npc_id:{}", currentXp - previousXp, hit, lastOpponentId);
+					hitBuffer.add(new Hit(hit, lastOpponent, attackStyle));
+				}
+
+				XpDrop xpDrop = new XpDrop(event.getSkill(), currentXp - previousXp, matchPrayerStyle(event.getSkill()), false, lastOpponent);
+				queue.add(xpDrop);
+			}
+
+			previous_exp[event.getSkill().ordinal()] = event.getXp();
+		});
 	}
 
 	@Subscribe


### PR DESCRIPTION
Previously used to use the old monster's xp multiplier to predict damage if you changed target on the same tick as your attack. 

This change makes the predicted hit stuff run later in the tick so InteractingChanged has a chance to happen first.

(similar thing used to happen with spec counter, so this should work)