### PR TITLE
set proper xp tracker background colour

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A plugin which allows you to customize XP drops in more ways than the default OS
 - Replace the XP tracker widget with a minimalistic one.
 
 #### Change log
+- v1.7.5 - Added setting to customize the border color of the xp tracker. - `@iipom`
 - v1.7.4 - Update NPC stats with dt2 bosses.
 - v1.7.3.2 - Fixes to account for Runelite api change.
 - v1.7.3.1 - Fix recolor xp drop to match up better with server. - `@hoheps`

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ dependencies {
 }
 
 group = 'com.xpdrops'
-version = '1.7.4'
+version = '1.7.5'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/com/xpdrops/config/XpDropsConfig.java
+++ b/src/main/java/com/xpdrops/config/XpDropsConfig.java
@@ -646,11 +646,24 @@ public interface XpDropsConfig extends Config
 		return Color.white;
 	}
 
+	@Alpha
+	@ConfigItem(
+		keyName = "xpTrackerBackgroundColor",
+		name = "XP tracker background color",
+		description = "Color for the Xp Tracker background",
+		position = 33,
+		section = xp_tracker_settings
+	)
+	default Color xpTrackerBackgroundColor()
+	{
+		return new Color(90, 82, 69);
+	}
+
 	@ConfigItem(
 		keyName = "xpTrackerClientTicksToLinger",
 		name = "Time until disappearance",
 		description = "Never disappear when set to 0. The amount of frames (50 per second) the XP tracker will show for.",
-		position = 33,
+		position = 34,
 		section = xp_tracker_settings
 	)
 	default int xpTrackerClientTicksToLinger()
@@ -662,7 +675,7 @@ public interface XpDropsConfig extends Config
 		keyName = "xpTrackerFadeOut",
 		name = "Fade out",
 		description = "Should the XP tracker fade out",
-		position = 34,
+		position = 35,
 		section = xp_tracker_settings
 	)
 	default boolean xpTrackerFadeOut()

--- a/src/main/java/com/xpdrops/config/XpDropsConfig.java
+++ b/src/main/java/com/xpdrops/config/XpDropsConfig.java
@@ -59,30 +59,33 @@ public interface XpDropsConfig extends Config
 	}
 
 	@ConfigSection(
-		name = "xp drop settings",
+		name = "Xp drop settings",
 		description = "Settings relating to xp drops",
 		position = 1
 	)
 	String xp_drop_settings = "xp_drop_settings";
 
 	@ConfigSection(
-		name = "font settings",
+		name = "Font settings",
 		description = "Settings relating to fonts",
-		position = 2
+		position = 2,
+		closedByDefault = true
 	)
 	String font_settings = "font_settings";
 
 	@ConfigSection(
-		name = "predicted hit",
+		name = "Predicted hit",
 		description = "Settings relating to predicted hit",
-		position = 3
+		position = 3,
+		closedByDefault = true
 	)
 	String predicted_hit = "predicted_hit";
 
 	@ConfigSection(
-		name = "xp tracker overlay",
+		name = "Xp tracker overlay",
 		description = "Settings relating to the xp tracker",
-		position = 4
+		position = 4,
+		closedByDefault = true
 	)
 	String xp_tracker_settings = "xp_tracker_settings";
 
@@ -648,13 +651,13 @@ public interface XpDropsConfig extends Config
 
 	@Alpha
 	@ConfigItem(
-		keyName = "xpTrackerBackgroundColor",
-		name = "XP tracker background color",
-		description = "Color for the Xp Tracker background",
+		keyName = "xpTrackerBorderColor",
+		name = "XP tracker border color",
+		description = "Color for the Xp Tracker border",
 		position = 33,
 		section = xp_tracker_settings
 	)
-	default Color xpTrackerBackgroundColor()
+	default Color xpTrackerBorderColor()
 	{
 		return new Color(90, 82, 69);
 	}

--- a/src/main/java/com/xpdrops/overlay/XpTrackerOverlay.java
+++ b/src/main/java/com/xpdrops/overlay/XpTrackerOverlay.java
@@ -9,6 +9,7 @@ import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.client.util.Text;
+import net.runelite.client.config.RuneLiteConfig;
 
 import javax.inject.Inject;
 import java.awt.Color;
@@ -22,19 +23,20 @@ public class XpTrackerOverlay extends Overlay
 	private final XpDropOverlayManager xpDropOverlayManager;
 	private final XpDropFontHandler xpDropFontHandler = new XpDropFontHandler();
 	private static final int PROGRESS_BAR_HEIGHT = 6;
-	private static final Color JAGEX_WIDGET_BACKGROUND_COLOR = new Color(90, 82, 69);
 
 	@Inject
 	private Client client;
 
 	private final XpTrackerService xpTrackerService;
+	private final RuneLiteConfig runeLiteConfig;
 
 	@Inject
-	private XpTrackerOverlay(XpDropsConfig config, XpDropOverlayManager xpDropOverlayManager, XpTrackerService xpTrackerService)
+	private XpTrackerOverlay(XpDropsConfig config, XpDropOverlayManager xpDropOverlayManager, XpTrackerService xpTrackerService, RuneLiteConfig runeLiteConfig)
 	{
 		this.config = config;
 		this.xpDropOverlayManager = xpDropOverlayManager;
 		this.xpTrackerService = xpTrackerService;
+		this.runeLiteConfig = runeLiteConfig;
 		setLayer(OverlayLayer.UNDER_WIDGETS);
 		setPosition(OverlayPosition.TOP_RIGHT);
 		setPriority(OverlayPriority.HIGHEST);
@@ -158,8 +160,8 @@ public class XpTrackerOverlay extends Overlay
 		int progressBarWidth = (int) (ratio * (width - 4));
 		int barHeight = PROGRESS_BAR_HEIGHT;
 
-		Color jagexBackgroundColor = new Color(JAGEX_WIDGET_BACKGROUND_COLOR.getRed(), JAGEX_WIDGET_BACKGROUND_COLOR.getGreen(), JAGEX_WIDGET_BACKGROUND_COLOR.getBlue(), alpha);
-		graphics.setColor(jagexBackgroundColor);
+		Color backgroundColor = new Color(runeLiteConfig.overlayBackgroundColor().getRed(), runeLiteConfig.overlayBackgroundColor().getGreen(), runeLiteConfig.overlayBackgroundColor().getBlue(), alpha);
+		graphics.setColor(backgroundColor);
 		graphics.fillRect(x, y, width, barHeight + 2);
 
 		Color blackBackgroundColor = new Color(0, 0, 0, alpha);

--- a/src/main/java/com/xpdrops/overlay/XpTrackerOverlay.java
+++ b/src/main/java/com/xpdrops/overlay/XpTrackerOverlay.java
@@ -157,8 +157,8 @@ public class XpTrackerOverlay extends Overlay
 		int progressBarWidth = (int) (ratio * (width - 4));
 		int barHeight = PROGRESS_BAR_HEIGHT;
 
-		Color backgroundColor = new Color(config.xpTrackerBackgroundColor().getRed(), config.xpTrackerBackgroundColor().getGreen(), config.xpTrackerBackgroundColor().getBlue(), alpha);
-		graphics.setColor(backgroundColor);
+		Color borderColor = new Color(config.xpTrackerBorderColor().getRed(), config.xpTrackerBorderColor().getGreen(), config.xpTrackerBorderColor().getBlue(), alpha);
+		graphics.setColor(borderColor);
 		graphics.fillRect(x, y, width, barHeight + 2);
 
 		Color blackBackgroundColor = new Color(0, 0, 0, alpha);

--- a/src/main/java/com/xpdrops/overlay/XpTrackerOverlay.java
+++ b/src/main/java/com/xpdrops/overlay/XpTrackerOverlay.java
@@ -9,7 +9,6 @@ import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.client.util.Text;
-import net.runelite.client.config.RuneLiteConfig;
 
 import javax.inject.Inject;
 import java.awt.Color;
@@ -28,15 +27,13 @@ public class XpTrackerOverlay extends Overlay
 	private Client client;
 
 	private final XpTrackerService xpTrackerService;
-	private final RuneLiteConfig runeLiteConfig;
 
 	@Inject
-	private XpTrackerOverlay(XpDropsConfig config, XpDropOverlayManager xpDropOverlayManager, XpTrackerService xpTrackerService, RuneLiteConfig runeLiteConfig)
+	private XpTrackerOverlay(XpDropsConfig config, XpDropOverlayManager xpDropOverlayManager, XpTrackerService xpTrackerService)
 	{
 		this.config = config;
 		this.xpDropOverlayManager = xpDropOverlayManager;
 		this.xpTrackerService = xpTrackerService;
-		this.runeLiteConfig = runeLiteConfig;
 		setLayer(OverlayLayer.UNDER_WIDGETS);
 		setPosition(OverlayPosition.TOP_RIGHT);
 		setPriority(OverlayPriority.HIGHEST);
@@ -160,7 +157,7 @@ public class XpTrackerOverlay extends Overlay
 		int progressBarWidth = (int) (ratio * (width - 4));
 		int barHeight = PROGRESS_BAR_HEIGHT;
 
-		Color backgroundColor = new Color(runeLiteConfig.overlayBackgroundColor().getRed(), runeLiteConfig.overlayBackgroundColor().getGreen(), runeLiteConfig.overlayBackgroundColor().getBlue(), alpha);
+		Color backgroundColor = new Color(config.xpTrackerBackgroundColor().getRed(), config.xpTrackerBackgroundColor().getGreen(), config.xpTrackerBackgroundColor().getBlue(), alpha);
 		graphics.setColor(backgroundColor);
 		graphics.fillRect(x, y, width, barHeight + 2);
 


### PR DESCRIPTION
Uses the overlay color set in the Runelite plugin as the background for the xp tracker progress bar, instead of the default jagex overlay color.