### PR TITLE
add predicted hit style option

### DIFF
--- a/src/main/java/com/xpdrops/PredictedHitDropStyle.java
+++ b/src/main/java/com/xpdrops/PredictedHitDropStyle.java
@@ -1,0 +1,8 @@
+package com.xpdrops;
+
+public enum PredictedHitDropStyle
+{
+	OFF,
+	XP_AND_HIT,
+	HIT_ONLY
+}

--- a/src/main/java/com/xpdrops/config/XpDropsConfig.java
+++ b/src/main/java/com/xpdrops/config/XpDropsConfig.java
@@ -1,5 +1,6 @@
 package com.xpdrops.config;
 
+import com.xpdrops.PredictedHitDropStyle;
 import com.xpdrops.overlay.TextComponentWithAlpha;
 import lombok.Getter;
 import net.runelite.client.config.Alpha;
@@ -442,9 +443,9 @@ public interface XpDropsConfig extends Config
 		position = 18,
 		section = predicted_hit
 	)
-	default boolean showPredictedHit()
+	default PredictedHitDropStyle showPredictedHit()
 	{
-		return false;
+		return PredictedHitDropStyle.OFF;
 	}
 
 	@ConfigItem(
@@ -468,7 +469,7 @@ public interface XpDropsConfig extends Config
 	)
 	default String predictedHitPrefix()
 	{
-		return "";
+		return " ";
 	}
 
 	@ConfigItem(

--- a/src/main/java/com/xpdrops/overlay/XpDropMerger.java
+++ b/src/main/java/com/xpdrops/overlay/XpDropMerger.java
@@ -1,5 +1,6 @@
 package com.xpdrops.overlay;
 
+import com.xpdrops.PredictedHitDropStyle;
 import com.xpdrops.XpDropStyle;
 import com.xpdrops.config.XpDropsConfig;
 import lombok.extern.slf4j.Slf4j;
@@ -33,7 +34,7 @@ public class XpDropMerger
 	// Removes merged xp drops from the list of to be put in flight.
 	public void mergeXpDrops(List<XpDropInFlight> dropsToBePutInFlight, List<XpDropInFlight> dropsInFlight)
 	{
-		if (config.showPredictedHit() && config.neverGroupPredictedHit())
+		if (config.showPredictedHit() != PredictedHitDropStyle.OFF && config.neverGroupPredictedHit())
 		{
 			mergePredictedHits(dropsToBePutInFlight, dropsInFlight);
 		}

--- a/src/main/java/com/xpdrops/overlay/XpDropOverlay.java
+++ b/src/main/java/com/xpdrops/overlay/XpDropOverlay.java
@@ -64,7 +64,7 @@ public class XpDropOverlay extends Overlay
 			{
 				continue;
 			}
-			String text = getDropText(xpDropInFlight);
+			String text = XpDropOverlayUtilities.getDropText(xpDropInFlight, config);
 
 			float xStart = xpDropInFlight.getXOffset();
 			float yStart = xpDropInFlight.getYOffset();
@@ -121,11 +121,6 @@ public class XpDropOverlay extends Overlay
 				drawIcons(graphics, xpDropInFlight.getIcons(), imageX, imageY, xpDropInFlight.getAlpha(), true);
 			}
 		}
-	}
-
-	private String getDropText(XpDropInFlight xpDropInFlight)
-	{
-		return XpDropOverlayUtilities.getDropText(xpDropInFlight, config);
 	}
 
 	private int drawIcons(Graphics2D graphics, int icons, int x, int y, float alpha, boolean rightToLeft)

--- a/src/main/java/com/xpdrops/overlay/XpDropOverlayManager.java
+++ b/src/main/java/com/xpdrops/overlay/XpDropOverlayManager.java
@@ -1,6 +1,7 @@
 package com.xpdrops.overlay;
 
 import com.xpdrops.CustomizableXpDropsPlugin;
+import com.xpdrops.PredictedHitDropStyle;
 import com.xpdrops.Skill;
 import com.xpdrops.XpDrop;
 import com.xpdrops.XpDropStyle;
@@ -277,6 +278,7 @@ public class XpDropOverlayManager
 		int totalHit = 0;
 		AttackStyle predictedHitAttackStyle = null;
 		Actor target = null;
+
 		{
 			Hit hit = plugin.getHitBuffer().poll();
 			while (hit != null)
@@ -289,7 +291,7 @@ public class XpDropOverlayManager
 			}
 		}
 
-		if (!config.showPredictedHit())
+		if (config.showPredictedHit() == PredictedHitDropStyle.OFF)
 		{
 			totalHit = 0;
 		}
@@ -307,7 +309,7 @@ public class XpDropOverlayManager
 			}
 		}
 
-		if (config.showPredictedHit() && config.neverGroupPredictedHit() && totalHit > 0 && !filteredHit)
+		if (config.showPredictedHit() != PredictedHitDropStyle.OFF && config.neverGroupPredictedHit() && totalHit > 0 && !filteredHit)
 		{
 			Skill skill = null;
 			if (predictedHitAttackStyle != null && predictedHitAttackStyle.getSkills().length > 0)

--- a/src/main/java/com/xpdrops/overlay/XpDropOverlayUtilities.java
+++ b/src/main/java/com/xpdrops/overlay/XpDropOverlayUtilities.java
@@ -57,34 +57,41 @@ public class XpDropOverlayUtilities
 
 	public static String getDropText(XpDropInFlight xpDropInFlight, XpDropsConfig config)
 	{
-		String text = XpDropOverlayManager.XP_FORMATTER.format(xpDropInFlight.getAmount());
+		final StringBuilder text = new StringBuilder();
 
-		if (xpDropInFlight.isPredictedHit())
+		switch (config.showPredictedHit())
 		{
-			// This line of text is a predicted hit without xp drop.
-			String colorTag = config.predictedHitColorOverride() ?
+			case OFF: // just xp
+				appendXpDrop(xpDropInFlight, config, text);
+				break;
+			case XP_AND_HIT: // xp and hit
+				appendXpDrop(xpDropInFlight, config, text);
+				appendPredictedHit(xpDropInFlight, config, text);
+				break;
+			case HIT_ONLY: // hit
+				appendPredictedHit(xpDropInFlight, config, text);
+				break;
+		}
+
+		return text.toString();
+	}
+
+	private static void appendXpDrop(XpDropInFlight xpDropInFlight, XpDropsConfig config, StringBuilder sb)
+	{
+		sb.append(wrapWithTags(RGBToHex(getColor(xpDropInFlight, config).getRGB())));
+		sb.append(config.xpDropPrefix());
+		sb.append(XpDropOverlayManager.XP_FORMATTER.format(xpDropInFlight.getAmount()));
+		sb.append(config.xpDropSuffix());
+	}
+
+	private static void appendPredictedHit(XpDropInFlight xpDropInFlight, XpDropsConfig config, StringBuilder sb)
+	{
+		sb.append(config.predictedHitColorOverride() ?
 				wrapWithTags(RGBToHex(config.predictedHitColor().getRGB())) :
-				wrapWithTags(RGBToHex(getColor(xpDropInFlight, config).getRGB()));
-			text = colorTag + config.predictedHitPrefix() + text + config.predictedHitSuffix();
-		}
-		else
-		{
-			// This line of text is an XP drop.
-			String colorTag = wrapWithTags(RGBToHex(getColor(xpDropInFlight, config).getRGB()));
-			text = colorTag + config.xpDropPrefix() + text + config.xpDropSuffix();
-		}
-
-		if (xpDropInFlight.getHit() > 0)
-		{
-			// Add predicted hit to the XP drop line of text.
-			String predictedHitColor = "";
-			if (config.predictedHitColorOverride())
-			{
-				predictedHitColor = wrapWithTags(RGBToHex(config.predictedHitColor().getRGB()));
-			}
-			text += predictedHitColor + " (" + config.predictedHitPrefix() + xpDropInFlight.getHit() + config.predictedHitSuffix() + ")";
-		}
-		return text;
+				wrapWithTags(RGBToHex(getColor(xpDropInFlight, config).getRGB())))
+			.append(config.predictedHitPrefix())
+			.append(xpDropInFlight.getHit())
+			.append(config.predictedHitSuffix());
 	}
 
 	public static int getIconWidthForIcons(Graphics2D graphics, int icons, XpDropsConfig config, XpDropOverlayManager xpDropOverlayManager)


### PR DESCRIPTION
Adds an option to show predicted hit only, and omit the xp part of the drop.

Also,
* Remove default parenthesis around predicted hit
* Set default predicted hit prefix to a single space

These are some local changes I've been using for a while now, and just periodically rebasing whenever there is an upstream update. Idk if there was ever a feature request for it by anyone else.

Feel free to close if you don't think it's necessary.