### PR TITLE
Add config option for appending predicted hit to vanilla XP drops

### DIFF
--- a/src/main/java/com/xpdrops/config/XpDropsConfig.java
+++ b/src/main/java/com/xpdrops/config/XpDropsConfig.java
@@ -533,10 +533,22 @@ public interface XpDropsConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "predictedHitVanillaAppend",
+		name = "Append to Vanilla XP Drop ",
+		description = "Appends the predicted hit to the Vanilla XP drops, respecting the RuneLite XP Drop plugin settings",
+		position = 26,
+		section = predicted_hit
+	)
+	default boolean predictedHitVanillaAppend()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "predictedHitIcon",
 		name = "Predicted hit icon",
 		description = "The style of the predicted hit icon. Only applicable when `Never group predicted hit` is enabled.",
-		position = 26,
+		position = 27,
 		section = predicted_hit
 	)
 	default PredictedHitIconStyle predictedHitIcon()
@@ -551,7 +563,7 @@ public interface XpDropsConfig extends Config
 			"Format as NPC id:xp modifier. Separate each entry with a newline.<br>" +
 			"For example if a goblin has an NPC id of 2 and an xp bonus of 35% then enter 2:1.35 in this field. If a rat has NPC id of 3 and an xp bonus of -75% then enter 3:0.25<br>"  +
 			"Modifiers entered here will supersede the modifiers shipped with the plugin!",
-		position = 27,
+		position = 28,
 		section = predicted_hit
 	)
 	default String predictedHitModifiers()


### PR DESCRIPTION
I've added a config option with prototype code that will append the `Predicted Hit` to the Vanilla XP Drops. I personally like the predicted hit functionality of this plugin but want to continue using the Vanilla XP drops along with the RuneLite's `XP Drops` plugin, the additional configs of this plugin are just not applicable to me.

<img width="327" height="123" alt="Medal_8eyvHo3iaC" src="https://github.com/user-attachments/assets/9d6f92c2-fb0d-4274-8117-63b694244bc6" />

This is more of a proof of concept than an actually fully-fledged out PR as I'm not familiar enough with this codebase, and why a `hitBuffer` was required so this may need to be tweaked some. Additionally maybe adding a config option to hide the overlay alongside this may work for my use case? Currently I just `Attach to player` and give it a massive offset so it's always off screen.
